### PR TITLE
Allow different files for different environments

### DIFF
--- a/gassetic.coffee
+++ b/gassetic.coffee
@@ -184,7 +184,7 @@ module.exports = class Gassetic
 		tasks = @getMimetypes()[type][@env].tasks
 		gutil.log ' -', gutil.colors.cyan(destinationFilenameConfigKey) if @log
 		sourceFiles = @getFilesForDestinationFile @getMimetypes()[type].files[destinationFilenameConfigKey]
-		destination = path.join @getMimetypes()[type][@env].outputFolder, destinationFilenameConfigKey
+		destination = @getDestinationDirectory(@getMimetypes()[type][@env], destinationFilenameConfigKey)
 		pipe = gulp.src sourceFiles
 		filtered = sourceFiles.filter (path) ->
 			path.indexOf('*') == -1 # remove all with stars
@@ -224,6 +224,14 @@ module.exports = class Gassetic
 			.on 'end', ->
 				result.resolve true
 		return result.promise
+
+	getDestinationDirectory: (configForType, key) ->
+		useNamespace = @isDev() || (configForType.useNamespace == undefined or configForType.useNamespace == true)
+		if useNamespace
+			destination = path.join configForType.outputFolder, key
+		else
+			destination = configForType.outputFolder
+		destination
 
 	getModuleMethod: (module, taskName) ->
 		levels = taskName.split '.'

--- a/gassetic.coffee
+++ b/gassetic.coffee
@@ -184,7 +184,7 @@ module.exports = class Gassetic
 		tasks = @getMimetypes()[type][@env].tasks
 		gutil.log ' -', gutil.colors.cyan(destinationFilenameConfigKey) if @log
 		sourceFiles = @getFilesForDestinationFile @getMimetypes()[type].files[destinationFilenameConfigKey]
-		destination = @getDestinationDirectory(@getMimetypes()[type][@env], destinationFilenameConfigKey)
+		destination = path.join @getMimetypes()[type][@env].outputFolder, destinationFilenameConfigKey
 		pipe = gulp.src sourceFiles
 		filtered = sourceFiles.filter (path) ->
 			path.indexOf('*') == -1 # remove all with stars
@@ -224,14 +224,6 @@ module.exports = class Gassetic
 			.on 'end', ->
 				result.resolve true
 		return result.promise
-
-	getDestinationDirectory: (configForType, key) ->
-		useNamespace = @isDev() or (configForType.useNamespace == undefined or configForType.useNamespace == true)
-		if useNamespace
-			destination = path.join configForType.outputFolder, key
-		else
-			destination = configForType.outputFolder
-		destination
 
 	getModuleMethod: (module, taskName) ->
 		levels = taskName.split '.'

--- a/gassetic.coffee
+++ b/gassetic.coffee
@@ -226,7 +226,7 @@ module.exports = class Gassetic
 		return result.promise
 
 	getDestinationDirectory: (configForType, key) ->
-		useNamespace = @isDev() || (configForType.useNamespace == undefined or configForType.useNamespace == true)
+		useNamespace = @isDev() or (configForType.useNamespace == undefined or configForType.useNamespace == true)
 		if useNamespace
 			destination = path.join configForType.outputFolder, key
 		else

--- a/gassetic.coffee
+++ b/gassetic.coffee
@@ -80,7 +80,19 @@ module.exports = class Gassetic
 	###
 	###
 	getSourceFilesForType: (type) ->
-		@getMimetypes()[type].files
+		files = {}
+		for key, list of @getMimetypes()[type].files
+			files[key] = @getFilesForDestinationFile list
+		files
+
+	getFilesForDestinationFile: (originalFiles) ->
+		files = []
+		for key, file of originalFiles
+			if typeof file is 'string'
+				files.push file
+			else if typeof file is 'object' and file[@env]
+				files.push file[@env]
+		files
 
 	clean: ->
 		result = q.defer()
@@ -171,7 +183,7 @@ module.exports = class Gassetic
 		result = q.defer()
 		tasks = @getMimetypes()[type][@env].tasks
 		gutil.log ' -', gutil.colors.cyan(destinationFilenameConfigKey) if @log
-		sourceFiles = @getMimetypes()[type].files[destinationFilenameConfigKey]
+		sourceFiles = @getFilesForDestinationFile @getMimetypes()[type].files[destinationFilenameConfigKey]
 		destination = path.join @getMimetypes()[type][@env].outputFolder, destinationFilenameConfigKey
 		pipe = gulp.src sourceFiles
 		filtered = sourceFiles.filter (path) ->
@@ -317,7 +329,7 @@ module.exports = class Gassetic
 				@watchSources @getMimetypes()[type].watch, type
 			else
 				for destinationFile of @getMimetypes()[type].files
-					sources = @getMimetypes()[type].files[destinationFile]
+					sources = @getFilesForDestinationFile @getMimetypes()[type].files[destinationFile]
 					@watchSources sources, type, destinationFile
 
 		gulp.watch @watchFiles

--- a/gassetic.coffee
+++ b/gassetic.coffee
@@ -47,10 +47,10 @@ module.exports = class Gassetic
 			if !@getMimetypes()[key].files?
 				throw 'missing file list for ' + key + ' mimetype'
 
-			src = @getSourceFilesForType key
 			what = Object.prototype.toString
-			if what.call(src) != '[object Object]'
+			if what.call(@getMimetypes()[key].files) != '[object Object]'
 				throw 'wrong file list for ' + key + ' mimetype'
+			src = @getSourceFilesForType key
 			for file of src
 				if what.call(file) != '[object String]'
 					throw 'invalid file "' + file + '" for ' + key + ' in ' + @env + ' environment'


### PR DESCRIPTION
This allows for different files to be used depending on environment.
It falls back to the regular way of working if there is a string.

I needed/wanted it so that I could have the debug version of Ember running in dev but the proper one in production.

Basically, you can list the files like so..

``` yaml
app.js:
    - file_1.js
    - { dev: file_2_dev.js, prod: file_2_prod.js }
    - { dev: file_3.js }
    - { prod: file_4.js }
    - file_5.js
```

.. and the generated files list should be correct one for the current environment.

If the "file" is a string then the location is taken as is.
If the "file" is an object then the value matching the key equalling the current environment is taken as the file location. If there is no key then no file is added.
