### PR TITLE
Add default task in gassetic.yml symfony example

### DIFF
--- a/Resources/doc/GasseticAndSymfony2.md
+++ b/Resources/doc/GasseticAndSymfony2.md
@@ -118,6 +118,10 @@ mimetypes:
 				
 replacementPaths:
     - src/**/*.html.twig
+
+default:
+    - js
+    - css
 ```
 
 #### 3. Run gulp


### PR DESCRIPTION
After trying the quick start in the symfony readme I was getting:

```
/usr/local/lib/node_modules/gassetic/gassetic.coffee:68
        if (this.getMimetypes()[key][this.env] == null) {
                                    ^

TypeError: Cannot read property 'dev' of null
  at Gassetic.module.exports.Gassetic.validateConfig (/usr/local/lib/node_modules/gassetic/gassetic.coffee:38:8)
  at new Gassetic (/usr/local/lib/node_modules/gassetic/gassetic.coffee:21:4)
  at Object.<anonymous> (/usr/local/lib/node_modules/gassetic/index.coffee:7:16)
  at Object.<anonymous> (/usr/local/lib/node_modules/gassetic/index.coffee:1:1)
  at Module._compile (module.js:399:26)
  at Object.loadFile (/usr/local/lib/node_modules/gassetic/node_modules/coffee-script/lib/coffee-script/register.js:16:19)
  at Module.load (/usr/local/lib/node_modules/gassetic/node_modules/coffee-script/lib/coffee-script/register.js:45:36)
  at Function.Module._load (module.js:302:12)
  at Module.require (module.js:355:17)
  at require (internal/module.js:13:17)
  at Object.<anonymous> (/usr/local/lib/node_modules/gassetic/bin.js:3:1)
  at Module._compile (module.js:399:26)
  at Object.Module._extensions..js (module.js:406:10)
  at Module.load (module.js:345:32)
  at Function.Module._load (module.js:302:12)
  at Function.Module.runMain (module.js:431:10)
  at startup (node.js:141:18)
  at node.js:977:3
```