### PR TITLE
Added brackets configuration.

### DIFF
--- a/gassetic.coffee
+++ b/gassetic.coffee
@@ -232,11 +232,11 @@ module.exports = class Gassetic
 				for filename in replacements[type][one]
 					scripts += @buildScriptString(type, filename) + os.EOL
 				regexs.push
-					pattern: new RegExp("<!-- " + @env + ':' + one + " -->([\\s\\S]*?)<!-- endbuild -->", "ig")
-					replacement: "<!-- " + @env + ":" + one + " -->" + scripts + "<!-- endbuild -->"
+					pattern: new RegExp( @config.replacementBrackets.open + " " + @env + ':' + one + " " + @config.replacementBrackets.close + "([\\s\\S]*?)" + @config.replacementBrackets.open + " endbuild " + @config.replacementBrackets.close, "ig")
+					replacement: @config.replacementBrackets.open + " " + @env + ":" + one + " " + @config.replacementBrackets.close + scripts + @config.replacementBrackets.open + " endbuild " + @config.replacementBrackets.close
 				regexs.push
-					pattern: new RegExp("<!-- " + '\\*' + ':' + one + " -->([\\s\\S]*?)<!-- endbuild -->", "ig")
-					replacement: "<!-- " + '*' + ":" + one + " -->" + scripts + "<!-- endbuild -->"
+					pattern: new RegExp(@config.replacementBrackets.open + " " + '\\*' + ':' + one + " " + @config.replacementBrackets.close + "([\\s\\S]*?)" + @config.replacementBrackets.open + " endbuild " + @config.replacementBrackets.close, "ig")
+					replacement: @config.replacementBrackets.open + " *:" + one + " " + @config.replacementBrackets.close + scripts + @config.replacementBrackets.open + " endbuild " + @config.replacementBrackets.close
 
 		allfiles = []
 		progress = []

--- a/gassetic.yml
+++ b/gassetic.yml
@@ -58,3 +58,6 @@ default:
     - js
 replacementPaths:
     - "./test/templates/**/*.html"
+replacementBrackets:
+    open: "<--"
+    close: "-->"

--- a/gassetic.yml
+++ b/gassetic.yml
@@ -59,5 +59,5 @@ default:
 replacementPaths:
     - "./test/templates/**/*.html"
 replacementBrackets:
-    open: "<--"
+    open: "<!--"
     close: "-->"


### PR DESCRIPTION
This pull request (for issue https://github.com/romanschejbal/gassetic/issues/57) adds new option to `gassetic.yml` and allows to select type of brackets, that gassetic seek in files.
**For example:**
if in gassetic.yml:

``` yml
replacementBrackets:
    open: '{#'
    close: '#}'
```

then gassetic find and replace `{# {env}:{file} #}{# endbuild #}` instead of `<!-- {env}:{file} --><!-- endbuild -->`
It gives pure html without further comments after compiling twig template.
