### PR TITLE
update gulp-sass and set livereload port in change event

### DIFF
--- a/gassetic.coffee
+++ b/gassetic.coffee
@@ -301,9 +301,9 @@ module.exports = class Gassetic
 			if lrParams.cert && lrParams.key
 				lrParams.key = fs.readFileSync lrParams.key
 				lrParams.cert = fs.readFileSync lrParams.cert
-			server = livereload.listen port, lrParams
+			livereload.listen port, lrParams
 		else
-			server = livereload.listen port
+			livereload.listen port
 
 		toWatch = []
 		for type in @getDefaultTypes()
@@ -322,7 +322,7 @@ module.exports = class Gassetic
 
 		gulp.watch @watchFiles
 			.on 'change', (e) =>
-				livereload.changed e
+				livereload.changed e, port
 
 	watchSources: (sources, type, destinationFile = '*') ->
 		gutil.log 'Watching', gutil.colors.cyan(sources.length), gutil.colors.magenta(type), 'paths for', gutil.colors.green(destinationFile), '...' if @log

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "gulp-mocha": "~0.4.1",
     "gulp-plumber": "^0.6.4",
     "gulp-sourcemaps": "^1.1.0",
-    "gulp-sass": "^0.7.2"
+    "gulp-sass": "^2.0.4"
   },
   "dependencies": {
     "coffee-script": "^1.7.1",


### PR DESCRIPTION
Actually, the `reloading` is on the default livereload port

see https://github.com/vohof/gulp-livereload/issues/51#issuecomment-68222933 
